### PR TITLE
Test that Ownable prevents non-owners from changing ownership.

### DIFF
--- a/test/ownable.js
+++ b/test/ownable.js
@@ -10,7 +10,7 @@ contract('Ownable', function(accounts) {
 
   it("changes owner after transfer", function(done) {
     var ownable = Ownable.deployed();
-    var other = '0xe682569efa3752a07fdc09885007c47beee803a7';
+    var other = accounts[1];
     return ownable.transfer(other)
     .then(function() {
       return ownable.owner();
@@ -20,4 +20,18 @@ contract('Ownable', function(accounts) {
     })
     .then(done)
   });
+
+  it("should prevent non-owners from transfering" ,function(done) {
+    var ownable = Ownable.deployed();
+    var other = accounts[2];
+    return ownable.transfer(other, {from: accounts[2]})
+    .then(function() {
+      return ownable.owner();
+    })
+    .then(function(owner) {
+      assert.isFalse(owner === other);
+    })
+    .then(done)
+  });
+
 });


### PR DESCRIPTION
I know one of the guidelines for testing is "Inputs for tests should not be generated randomly."

However, to perform a transaction from an address other than the creator of the contract, I needed to specify a from address in the transaction object. It had to be one of the addresses that testrpc generates and puts into web3.eth.accounts. Attempting to use an address that is not one of the generated addresses results in this error: "Error: could not unlock signer account."

Besides the fact that code looks cleaner with "accounts[1]" instead of a long hex string, perhaps the error I described above is an incentive to allow the use of the accounts array in tests.